### PR TITLE
Implement sticker floor watcher bot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+BOT_TOKEN=123456:ABC
+DB_DSN=postgresql+asyncpg://bot:bot@postgres:5432/stickers
+REDIS_DSN=redis://redis:6379/0
+TZ=Europe/Amsterdam
+WEBHOOK_URL=
+WEBHOOK_SECRET=
+HARBOR_API_URL=https://api.harbor.gg
+WHITELIST_IDS=123456789
+RUN_SCHEDULER=true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.env
+*.egg-info/
+.venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y build-essential && rm -rf /var/lib/apt/lists/*
+
+COPY pyproject.toml ./
+RUN pip install --upgrade pip && pip install .
+
+COPY sticker_watcher ./sticker_watcher
+COPY .env.example ./.env.example
+
+CMD ["uvicorn", "sticker_watcher.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# Sticker Floor Watcher
+
+Приватный бот для наблюдения за коллекциями стикеров на Harbor, MRKT, Palace и Pixel Market. Отправляет мгновенные алерты о падении пола, редких листингах, тонком полу и формирует 15-минутные отчёты и дайджесты (10:00 и 20:00 Europe/Amsterdam).
+
+## Основные возможности
+
+- Асинхронные адаптеры для Harbor (REST API) и Mini App рынков (через валидированное initData).
+- Хранение истории floor/depth в PostgreSQL, кэш и антиспам на Redis.
+- Aiogram 3 + FastAPI вебхук, отдельный воркер с APScheduler для мониторинга коллекций и отправки дайджестов.
+- Команды бота: `/watch`, `/unwatch`, `/list`, `/digest`, `/mute`, `/unmute`, `/export`.
+
+## Структура
+
+```
+sticker_watcher/
+  adapters/         # Harbor + Telegram Mini App интеграции
+  bot/              # Aiogram bot, обработчики и middleware
+  services/         # Сcheduler, метрики, уведомления, digest менеджер
+  models/           # SQLAlchemy модели БД
+  main.py           # FastAPI приложение (вебхук)
+  worker.py         # Фоновый воркер с APScheduler
+```
+
+## Быстрый старт (Docker Compose)
+
+```bash
+cp .env.example .env
+# заполните переменные (токен бота, initData, deeplink, whitelist)
+docker compose up --build
+```
+
+Сервис `api` поднимает FastAPI + вебхук, `worker` запускает мониторинг. Postgres и Redis автоматически стартуют.
+
+## Подготовка БД
+
+После настройки `.env` выполните миграцию схемы:
+
+```bash
+docker compose run --rm api python scripts/create_tables.py
+```
+
+Добавьте записи рынков/коллекций (market code: `harbor`, `mrkt`, `palace`, `pixel`) и meta с конфигурацией API или Mini App.
+
+## Тестирование
+
+- `ruff` для статического анализа.
+- (опционально) `pytest` для unit-тестов.
+
+## Лицензия
+
+Проект приватный, распространяется только внутри команды.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: '3.9'
+services:
+  api:
+    build: .
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      RUN_SCHEDULER: "false"
+    ports:
+      - "8000:8000"
+    depends_on:
+      - postgres
+      - redis
+  worker:
+    build: .
+    command: ["python", "-m", "sticker_watcher.worker"]
+    restart: unless-stopped
+    env_file:
+      - .env
+    depends_on:
+      - postgres
+      - redis
+  postgres:
+    image: postgres:15
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: stickers
+      POSTGRES_USER: bot
+      POSTGRES_PASSWORD: bot
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+  redis:
+    image: redis:7
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+volumes:
+  pgdata:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,43 @@
+[project]
+name = "sticker-floor-watcher"
+version = "0.1.0"
+description = "Private Telegram bot tracking sticker floors across Harbor, MRKT, Palace, Pixel Market"
+requires-python = ">=3.11"
+authors = [{name = "Sticker Labs"}]
+dependencies = [
+    "aiogram==3.13.1",
+    "fastapi==0.114.1",
+    "uvicorn[standard]==0.30.6",
+    "httpx==0.27.2",
+    "pydantic==2.9.2",
+    "pydantic-settings==2.6.1",
+    "SQLAlchemy==2.0.35",
+    "asyncpg==0.29.0",
+    "redis==5.0.8",
+    "APScheduler==3.10.4",
+    "python-dotenv==1.0.1",
+    "pytz==2024.1",
+]
+
+[project.optional-dependencies]
+dev = [
+    "ruff==0.6.9",
+    "pytest==8.3.2",
+]
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP"]
+ignore = ["E501"]
+
+[tool.ruff.lint.isort]
+combine-as-imports = true
+known-first-party = ["sticker_watcher"]
+

--- a/scripts/create_tables.py
+++ b/scripts/create_tables.py
@@ -1,0 +1,14 @@
+import asyncio
+
+from sticker_watcher.db import engine
+from sticker_watcher.models import tables  # noqa: F401
+from sticker_watcher.models.base import Base
+
+
+async def main() -> None:
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/sticker_watcher/adapters/__init__.py
+++ b/sticker_watcher/adapters/__init__.py
@@ -1,0 +1,17 @@
+from .base import Listing, MarketAdapter, Sale
+from .harbor import HarborAdapter
+from .mrkt import MrktAdapter
+from .palace import PalaceAdapter
+from .pixel import PixelAdapter
+from .tma import TmaAdapter
+
+__all__ = [
+    "Listing",
+    "MarketAdapter",
+    "Sale",
+    "HarborAdapter",
+    "MrktAdapter",
+    "PalaceAdapter",
+    "PixelAdapter",
+    "TmaAdapter",
+]

--- a/sticker_watcher/adapters/base.py
+++ b/sticker_watcher/adapters/base.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import abc
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+
+
+@dataclass(frozen=True)
+class Listing:
+    asset_id: str
+    price: Decimal
+    quantity: int = 1
+    seller: str | None = None
+    ts: datetime | None = None
+
+
+@dataclass(frozen=True)
+class Sale:
+    asset_id: str
+    price: Decimal
+    ts: datetime
+    tx_hash: str | None = None
+
+
+class MarketAdapter(abc.ABC):
+    code: str
+
+    @abc.abstractmethod
+    async def fetch_active_listings(self, collection_code: str) -> Sequence[Listing]:
+        """Return active listings sorted by price ascending."""
+
+    async def fetch_recent_sales(self, collection_code: str, limit: int = 50) -> Sequence[Sale]:
+        """Fetch recent sales for the collection."""
+        return []
+
+    async def close(self) -> None:
+        return None
+
+
+__all__ = ["Listing", "Sale", "MarketAdapter"]

--- a/sticker_watcher/adapters/harbor.py
+++ b/sticker_watcher/adapters/harbor.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+import httpx
+
+from .base import Listing, MarketAdapter, Sale
+
+
+@dataclass(slots=True)
+class HarborAdapter(MarketAdapter):
+    base_url: str
+    client: httpx.AsyncClient | None = None
+
+    code: str = "harbor"
+
+    def __post_init__(self) -> None:
+        if self.client is None:
+            self.client = httpx.AsyncClient(base_url=self.base_url, timeout=10.0)
+
+    async def fetch_active_listings(self, collection_code: str) -> Sequence[Listing]:
+        assert self.client is not None
+        response = await self.client.get(
+            f"/marketplace/collections/{collection_code}/listings",
+            params={"limit": 200},
+        )
+        response.raise_for_status()
+        data = response.json()
+        items = data.get("items") if isinstance(data, dict) else data
+        listings: list[Listing] = []
+        if not isinstance(items, list):
+            return listings
+        for item in items:
+            price = self._extract_price(item)
+            if price is None:
+                continue
+            listings.append(
+                Listing(
+                    asset_id=str(item.get("tokenId") or item.get("id") or ""),
+                    price=price,
+                    quantity=int(item.get("quantity", 1)),
+                    seller=item.get("sellerAddress") or item.get("seller"),
+                )
+            )
+        listings.sort(key=lambda x: x.price)
+        return listings
+
+    async def fetch_recent_sales(self, collection_code: str, limit: int = 50) -> Sequence[Sale]:
+        assert self.client is not None
+        response = await self.client.get(
+            f"/marketplace/collections/{collection_code}/sales",
+            params={"limit": limit},
+        )
+        response.raise_for_status()
+        data = response.json()
+        items = data.get("items") if isinstance(data, dict) else data
+        sales: list[Sale] = []
+        if not isinstance(items, list):
+            return sales
+        for item in items:
+            price = self._extract_price(item)
+            ts_raw = item.get("timestamp") or item.get("createdAt")
+            if price is None or ts_raw is None:
+                continue
+            sales.append(
+                Sale(
+                    asset_id=str(item.get("tokenId") or item.get("id") or ""),
+                    price=price,
+                    ts=self._parse_ts(ts_raw),
+                    tx_hash=item.get("txHash") or item.get("transactionHash"),
+                )
+            )
+        return sales
+
+    async def close(self) -> None:
+        if self.client is not None:
+            await self.client.aclose()
+
+    @staticmethod
+    def _extract_price(payload: Any) -> Decimal | None:
+        value = payload.get("price") or payload.get("askPrice") or payload.get("floorPrice")
+        if value is None:
+            return None
+        if isinstance(value, dict):
+            value = value.get("amount") or value.get("value")
+        try:
+            return Decimal(str(value))
+        except Exception:
+            return None
+
+    @staticmethod
+    def _parse_ts(value: Any) -> datetime:
+        if isinstance(value, int | float):
+            return datetime.fromtimestamp(float(value), tz=UTC)
+        if isinstance(value, str):
+            try:
+                if value.endswith("Z"):
+                    value = value[:-1] + "+00:00"
+                return datetime.fromisoformat(value)
+            except ValueError:
+                pass
+        return datetime.now(tz=UTC)
+
+
+__all__ = ["HarborAdapter"]

--- a/sticker_watcher/adapters/mrkt.py
+++ b/sticker_watcher/adapters/mrkt.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .tma import TmaAdapter
+
+
+@dataclass(slots=True)
+class MrktAdapter(TmaAdapter):
+    code: str = "mrkt"
+
+
+__all__ = ["MrktAdapter"]

--- a/sticker_watcher/adapters/palace.py
+++ b/sticker_watcher/adapters/palace.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .tma import TmaAdapter
+
+
+@dataclass(slots=True)
+class PalaceAdapter(TmaAdapter):
+    code: str = "palace"
+
+
+__all__ = ["PalaceAdapter"]

--- a/sticker_watcher/adapters/pixel.py
+++ b/sticker_watcher/adapters/pixel.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .tma import TmaAdapter
+
+
+@dataclass(slots=True)
+class PixelAdapter(TmaAdapter):
+    code: str = "pixel"
+
+
+__all__ = ["PixelAdapter"]

--- a/sticker_watcher/adapters/tma.py
+++ b/sticker_watcher/adapters/tma.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+import httpx
+
+from .base import Listing, MarketAdapter, Sale
+
+
+@dataclass(slots=True)
+class TmaAdapter(MarketAdapter):
+    code: str
+    base_url: str
+    init_data: str
+    session_headers: Mapping[str, str] | None = None
+    client: httpx.AsyncClient | None = None
+
+    def __post_init__(self) -> None:
+        if self.client is None:
+            headers = {"User-Agent": "StickerFloorWatcher/1.0"}
+            if self.session_headers:
+                headers.update(self.session_headers)
+            self.client = httpx.AsyncClient(base_url=self.base_url, headers=headers, timeout=10.0)
+
+    async def fetch_active_listings(self, collection_code: str) -> Sequence[Listing]:
+        assert self.client is not None
+        response = await self.client.get(
+            "/collections/listings",
+            params={"collection": collection_code, "limit": 200},
+            headers={"X-Telegram-Init-Data": self.init_data},
+        )
+        response.raise_for_status()
+        payload = response.json()
+        items = payload.get("items") if isinstance(payload, dict) else payload
+        return self._parse_listings(items)
+
+    async def fetch_recent_sales(self, collection_code: str, limit: int = 50) -> Sequence[Sale]:
+        assert self.client is not None
+        response = await self.client.get(
+            "/collections/sales",
+            params={"collection": collection_code, "limit": limit},
+            headers={"X-Telegram-Init-Data": self.init_data},
+        )
+        response.raise_for_status()
+        payload = response.json()
+        items = payload.get("items") if isinstance(payload, dict) else payload
+        return self._parse_sales(items)
+
+    async def close(self) -> None:
+        if self.client is not None:
+            await self.client.aclose()
+
+    def _parse_listings(self, items: Any) -> Sequence[Listing]:
+        listings: list[Listing] = []
+        if not isinstance(items, list):
+            return listings
+        for item in items:
+            price = self._extract_price(item)
+            if price is None:
+                continue
+            listings.append(
+                Listing(
+                    asset_id=str(item.get("id") or item.get("tokenId") or ""),
+                    price=price,
+                    quantity=int(item.get("quantity", 1)),
+                    seller=item.get("seller") or item.get("owner"),
+                )
+            )
+        listings.sort(key=lambda x: x.price)
+        return listings
+
+    def _parse_sales(self, items: Any) -> Sequence[Sale]:
+        sales: list[Sale] = []
+        if not isinstance(items, list):
+            return sales
+        for item in items:
+            price = self._extract_price(item)
+            ts_raw = item.get("timestamp") or item.get("createdAt")
+            if price is None or ts_raw is None:
+                continue
+            sales.append(
+                Sale(
+                    asset_id=str(item.get("id") or item.get("tokenId") or ""),
+                    price=price,
+                    ts=self._parse_ts(ts_raw),
+                    tx_hash=item.get("txHash") or item.get("transactionHash"),
+                )
+            )
+        return sales
+
+    @staticmethod
+    def _extract_price(payload: Any) -> Decimal | None:
+        value = payload.get("price") or payload.get("askPrice") or payload.get("amount")
+        if value is None:
+            return None
+        if isinstance(value, dict):
+            value = value.get("amount") or value.get("value")
+        try:
+            return Decimal(str(value))
+        except Exception:
+            return None
+
+    @staticmethod
+    def _parse_ts(value: Any) -> datetime:
+        if isinstance(value, int | float):
+            return datetime.fromtimestamp(float(value), tz=UTC)
+        if isinstance(value, str):
+            try:
+                if value.endswith("Z"):
+                    value = value[:-1] + "+00:00"
+                return datetime.fromisoformat(value)
+            except ValueError:
+                pass
+        return datetime.now(tz=UTC)
+
+
+__all__ = ["TmaAdapter"]

--- a/sticker_watcher/bot/__init__.py
+++ b/sticker_watcher/bot/__init__.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from aiogram import Bot, Dispatcher
+from aiogram.client.default import DefaultBotProperties
+from aiogram.enums import ParseMode
+
+from ..config import get_settings
+from .handlers import router as handlers_router
+from .middlewares.whitelist import WhitelistMiddleware
+
+settings = get_settings()
+
+bot = Bot(token=settings.bot_token, default=DefaultBotProperties(parse_mode=ParseMode.HTML))
+dispatcher = Dispatcher()
+dispatcher.include_router(handlers_router)
+dispatcher.message.middleware(WhitelistMiddleware(settings.whitelist_ids))
+
+dispatcher.callback_query.middleware(WhitelistMiddleware(settings.whitelist_ids))
+
+__all__ = ["bot", "dispatcher"]

--- a/sticker_watcher/bot/handlers/__init__.py
+++ b/sticker_watcher/bot/handlers/__init__.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from aiogram import Router
+
+from . import commands
+
+router = Router()
+router.include_router(commands.router)
+
+__all__ = ["router"]

--- a/sticker_watcher/bot/handlers/commands.py
+++ b/sticker_watcher/bot/handlers/commands.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import csv
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal, InvalidOperation
+from io import StringIO
+
+from aiogram import Router
+from aiogram.filters import Command
+from aiogram.types import BufferedInputFile, Message
+from sqlalchemy import and_, select
+
+from ...config import get_settings
+from ...db import SessionLocal
+from ...models import tables as db_models
+from ...services import repository
+
+router = Router()
+settings = get_settings()
+
+
+@router.message(Command("start"))
+async def cmd_start(message: Message) -> None:
+    async with SessionLocal() as session:
+        await repository.ensure_user(session, message.from_user.id, settings.timezone)
+        await session.commit()
+    await message.answer(
+        "Привет! Я наблюдаю за floor выбранных коллекций. Используй /watch, чтобы добавить коллекцию."
+    )
+
+
+@router.message(Command("watch"))
+async def cmd_watch(message: Message) -> None:
+    parts = (message.text or "").split()
+    if len(parts) < 3:
+        await message.answer("Использование: /watch <market> <collection_code> [threshold]")
+        return
+    market_code = parts[1].lower()
+    collection_code = parts[2]
+    threshold = None
+    if len(parts) >= 4:
+        try:
+            threshold = Decimal(parts[3])
+        except InvalidOperation:
+            await message.answer("Некорректное значение порога.")
+            return
+
+    async with SessionLocal() as session:
+        user = await repository.ensure_user(session, message.from_user.id, settings.timezone)
+        collection = await repository.get_collection(session, market_code, collection_code)
+        if not collection:
+            await message.answer("Коллекция не найдена. Обнови конфигурацию в БД.")
+            return
+        await repository.add_watch(session, user, collection, threshold)
+        await session.commit()
+    await message.answer(f"Коллекция {collection.name} добавлена в наблюдение.")
+
+
+@router.message(Command("unwatch"))
+async def cmd_unwatch(message: Message) -> None:
+    parts = (message.text or "").split()
+    if len(parts) < 3:
+        await message.answer("Использование: /unwatch <market> <collection_code>")
+        return
+    market_code = parts[1].lower()
+    collection_code = parts[2]
+
+    async with SessionLocal() as session:
+        user = await repository.ensure_user(session, message.from_user.id, settings.timezone)
+        collection = await repository.get_collection(session, market_code, collection_code)
+        if not collection:
+            await message.answer("Коллекция не найдена.")
+            return
+        await repository.remove_watch(session, user, collection)
+        await session.commit()
+    await message.answer("Наблюдение отключено.")
+
+
+@router.message(Command("list"))
+async def cmd_list(message: Message) -> None:
+    async with SessionLocal() as session:
+        user = await repository.ensure_user(session, message.from_user.id, settings.timezone)
+        watches = await repository.list_watches(session, user)
+    if not watches:
+        await message.answer("Список пуст.")
+        return
+    lines = ["Текущие наблюдения:"]
+    for collection, market, watch in watches:
+        threshold = f", порог {watch.threshold_ton}" if watch.threshold_ton else ""
+        lines.append(f"• {market.code.upper()} — {collection.name} ({collection.code}){threshold}")
+    await message.answer("\n".join(lines))
+
+
+@router.message(Command("mute"))
+async def cmd_mute(message: Message) -> None:
+    parts = (message.text or "").split()
+    minutes = int(parts[1]) if len(parts) >= 2 else 60
+    until = datetime.now(UTC) + timedelta(minutes=minutes)
+    async with SessionLocal() as session:
+        user = await repository.ensure_user(session, message.from_user.id, settings.timezone)
+        await repository.set_mute(session, user, until)
+        await session.commit()
+    await message.answer(f"Уведомления заглушены до {until:%H:%M UTC}.")
+
+
+@router.message(Command("unmute"))
+async def cmd_unmute(message: Message) -> None:
+    async with SessionLocal() as session:
+        user = await repository.ensure_user(session, message.from_user.id, settings.timezone)
+        await repository.set_mute(session, user, None)
+        await session.commit()
+    await message.answer("Уведомления включены.")
+
+
+@router.message(Command("export"))
+async def cmd_export(message: Message) -> None:
+    parts = (message.text or "").split()
+    if len(parts) < 4:
+        await message.answer("Использование: /export <market> <collection_code> <days>")
+        return
+    market_code = parts[1].lower()
+    collection_code = parts[2]
+    days = int(parts[3])
+    since = datetime.now(UTC) - timedelta(days=days)
+
+    async with SessionLocal() as session:
+        await repository.ensure_user(session, message.from_user.id, settings.timezone)
+        collection = await repository.get_collection(session, market_code, collection_code)
+        if not collection:
+            await message.answer("Коллекция не найдена.")
+            return
+        stmt = (
+            select(db_models.Price)
+            .where(
+                and_(
+                    db_models.Price.collection_id == collection.id,
+                    db_models.Price.ts >= since,
+                )
+            )
+            .order_by(db_models.Price.ts)
+        )
+        rows = (await session.execute(stmt)).scalars().all()
+
+    if not rows:
+        await message.answer("Нет данных за выбранный период.")
+        return
+
+    buffer = StringIO()
+    writer = csv.writer(buffer)
+    writer.writerow(["timestamp", "floor", "depth_5", "spread"])
+    for row in rows:
+        writer.writerow([row.ts.isoformat(), row.floor, row.depth_5, row.spread])
+    buffer.seek(0)
+
+    document = BufferedInputFile(buffer.getvalue().encode("utf-8"), filename=f"{market_code}_{collection_code}.csv")
+    await message.answer_document(document=document, caption="Экспорт данных")

--- a/sticker_watcher/bot/middlewares/whitelist.py
+++ b/sticker_watcher/bot/middlewares/whitelist.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from aiogram import BaseMiddleware
+from aiogram.types import Update
+
+from ...config import get_settings
+
+
+class WhitelistMiddleware(BaseMiddleware):
+    def __init__(self, allowed_ids: set[int] | None = None) -> None:
+        self.allowed_ids = allowed_ids or get_settings().whitelist_ids
+
+    async def __call__(self, handler, event: Update, data):  # type: ignore[override]
+        user = event.from_user if hasattr(event, "from_user") else None
+        if user is None or (self.allowed_ids and user.id not in self.allowed_ids):
+            if hasattr(event, "answer"):
+                await event.answer("🚫 Доступ закрыт")
+            return None
+        return await handler(event, data)
+
+
+__all__ = ["WhitelistMiddleware"]

--- a/sticker_watcher/config.py
+++ b/sticker_watcher/config.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from functools import lru_cache
+
+from pydantic import BaseModel, Field, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class RateLimitConfig(BaseModel):
+    harbor_per_min: int = Field(30, description="Allowed Harbor API requests per minute")
+    mrkt_per_min: int = Field(20, description="Allowed MRKT backend requests per minute")
+    palace_per_min: int = Field(20, description="Allowed Palace backend requests per minute")
+    pixel_per_min: int = Field(20, description="Allowed Pixel backend requests per minute")
+
+
+class AlertConfig(BaseModel):
+    min_interval_sec: int = Field(60, ge=0)
+    same_event_cooldown_sec: int = Field(600, ge=0)
+    under_floor_pct: float = Field(7.0, ge=0.0)
+    depth_delta_pct: float = Field(5.0, ge=0.0)
+    thin_floor_min_lots: int = Field(5, ge=0)
+
+
+class DigestConfig(BaseModel):
+    enabled: bool = True
+    times: list[str] = Field(default_factory=lambda: ["10:00", "20:00"])
+
+    @field_validator("times")
+    @classmethod
+    def _validate_times(cls, values: list[str]) -> list[str]:
+        cleaned: list[str] = []
+        for value in values:
+            hour, minute = value.split(":", 1)
+            if not (hour.isdigit() and minute.isdigit()):
+                raise ValueError("Digest time must be HH:MM")
+            h, m = int(hour), int(minute)
+            if not (0 <= h < 24 and 0 <= m < 60):
+                raise ValueError("Digest time must be within 00:00-23:59")
+            cleaned.append(f"{h:02d}:{m:02d}")
+        return sorted(dict.fromkeys(cleaned))
+
+
+class Settings(BaseSettings):
+    bot_token: str = Field(..., env="BOT_TOKEN")
+    db_dsn: str = Field(..., env="DB_DSN")
+    redis_dsn: str = Field(..., env="REDIS_DSN")
+    timezone: str = Field("Europe/Amsterdam", env="TZ")
+
+    whitelist_ids: set[int] = Field(default_factory=set, env="WHITELIST_IDS")
+
+    rate_limits: RateLimitConfig = Field(default_factory=RateLimitConfig)
+    alerts: AlertConfig = Field(default_factory=AlertConfig)
+    digest: DigestConfig = Field(default_factory=DigestConfig)
+
+    harbor_api_url: str = Field("https://api.harbor.gg", env="HARBOR_API_URL")
+
+    webhook_url: str | None = Field(None, env="WEBHOOK_URL")
+    webhook_path: str = Field("/webhook", env="WEBHOOK_PATH")
+    webhook_secret: str | None = Field(None, env="WEBHOOK_SECRET")
+    run_scheduler: bool = Field(True, env="RUN_SCHEDULER")
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", case_sensitive=False)
+
+    @field_validator("whitelist_ids", mode="before")
+    @classmethod
+    def _parse_whitelist(cls, value: str | set[int] | None) -> set[int]:
+        if value is None:
+            return set()
+        if isinstance(value, set):
+            return value
+        ids = set()
+        for item in value.split(","):
+            item = item.strip()
+            if not item:
+                continue
+            ids.add(int(item))
+        return ids
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()
+
+
+__all__ = ["AlertConfig", "DigestConfig", "RateLimitConfig", "Settings", "get_settings"]

--- a/sticker_watcher/db.py
+++ b/sticker_watcher/db.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from .config import get_settings
+
+_settings = get_settings()
+
+engine: AsyncEngine = create_async_engine(_settings.db_dsn, echo=False, pool_pre_ping=True)
+SessionLocal = async_sessionmaker(bind=engine, expire_on_commit=False)
+
+
+@asynccontextmanager
+async def session_scope() -> AsyncSession:
+    async with SessionLocal() as session:
+        try:
+            yield session
+        finally:
+            await session.close()
+
+
+__all__ = ["engine", "session_scope", "SessionLocal"]

--- a/sticker_watcher/logging.py
+++ b/sticker_watcher/logging.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from logging.config import dictConfig
+
+
+def setup_logging(level: str = "INFO") -> None:
+    dictConfig(
+        {
+            "version": 1,
+            "disable_existing_loggers": False,
+            "formatters": {
+                "default": {
+                    "format": "%(asctime)s %(levelname)s %(name)s - %(message)s",
+                }
+            },
+            "handlers": {
+                "console": {
+                    "class": "logging.StreamHandler",
+                    "formatter": "default",
+                }
+            },
+            "root": {"handlers": ["console"], "level": level},
+        }
+    )
+
+
+__all__ = ["setup_logging"]

--- a/sticker_watcher/main.py
+++ b/sticker_watcher/main.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import asyncio
+
+from aiogram.types import Update
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from .bot import bot, dispatcher
+from .config import get_settings
+from .logging import setup_logging
+from .services.scheduler import WatchScheduler
+
+app = FastAPI(title="Sticker Floor Watcher")
+settings = get_settings()
+setup_logging()
+scheduler = WatchScheduler(settings)
+
+
+@app.on_event("startup")
+async def on_startup() -> None:
+    if settings.webhook_url:
+        await bot.set_webhook(settings.webhook_url, secret_token=settings.webhook_secret)
+    if settings.run_scheduler:
+        asyncio.create_task(scheduler.start())
+
+
+@app.on_event("shutdown")
+async def on_shutdown() -> None:
+    await scheduler.shutdown()
+    await bot.session.close()
+
+
+@app.post(settings.webhook_path)
+async def telegram_webhook(request: Request) -> JSONResponse:
+    if settings.webhook_secret:
+        token = request.headers.get("X-Telegram-Bot-Api-Secret-Token")
+        if token != settings.webhook_secret:
+            raise HTTPException(status_code=403, detail="Invalid secret token")
+    data = await request.json()
+    update = Update.model_validate(data)
+    await dispatcher.feed_update(bot, update)
+    return JSONResponse({"ok": True})
+
+
+@app.get("/healthz")
+async def healthcheck() -> JSONResponse:
+    return JSONResponse({"status": "ok"})
+
+
+__all__ = ["app"]

--- a/sticker_watcher/models/__init__.py
+++ b/sticker_watcher/models/__init__.py
@@ -1,0 +1,4 @@
+from . import tables
+from .base import Base
+
+__all__ = ["Base", "tables"]

--- a/sticker_watcher/models/base.py
+++ b/sticker_watcher/models/base.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, func
+from sqlalchemy.orm import DeclarativeBase, Mapped, declared_attr, mapped_column
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class TimestampMixin:
+    @declared_attr
+    def created_at(cls) -> Mapped[datetime]:  # type: ignore[override]
+        return mapped_column(DateTime(timezone=True), server_default=func.now())
+
+
+__all__ = ["Base", "TimestampMixin"]

--- a/sticker_watcher/models/tables.py
+++ b/sticker_watcher/models/tables.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+
+from sqlalchemy import (
+    JSON,
+    BigInteger,
+    Boolean,
+    ForeignKey,
+    Integer,
+    Numeric,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    tg_id: Mapped[int] = mapped_column(BigInteger, unique=True, nullable=False)
+    tz: Mapped[str] = mapped_column(Text, default="Europe/Amsterdam", nullable=False)
+    mute_until: Mapped[datetime | None] = mapped_column(default=None)
+
+    watches: Mapped[list[Watch]] = relationship(back_populates="user")
+
+
+class Market(Base):
+    __tablename__ = "markets"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    code: Mapped[str] = mapped_column(Text, unique=True, nullable=False)
+
+    collections: Mapped[list[Collection]] = relationship(back_populates="market")
+
+
+class Collection(Base):
+    __tablename__ = "collections"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    market_id: Mapped[int] = mapped_column(ForeignKey("markets.id"), nullable=False)
+    code: Mapped[str] = mapped_column(Text, nullable=False)
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    meta: Mapped[dict] = mapped_column(JSON, default=dict, nullable=False)
+
+    market: Mapped[Market] = relationship(back_populates="collections")
+    watches: Mapped[list[Watch]] = relationship(back_populates="collection")
+    prices: Mapped[list[Price]] = relationship(back_populates="collection")
+    sales: Mapped[list[Sale]] = relationship(back_populates="collection")
+
+
+class Watch(Base):
+    __tablename__ = "watches"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
+    collection_id: Mapped[int] = mapped_column(ForeignKey("collections.id"), nullable=False)
+    threshold_ton: Mapped[Decimal | None] = mapped_column(Numeric(24, 6), nullable=True)
+    enabled: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+
+    user: Mapped[User] = relationship(back_populates="watches")
+    collection: Mapped[Collection] = relationship(back_populates="watches")
+
+    __table_args__ = (UniqueConstraint("user_id", "collection_id", name="uq_user_collection"),)
+
+
+class Price(Base):
+    __tablename__ = "prices"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    collection_id: Mapped[int] = mapped_column(ForeignKey("collections.id"), nullable=False)
+    ts: Mapped[datetime] = mapped_column(nullable=False)
+    floor: Mapped[Decimal] = mapped_column(Numeric(24, 6), nullable=False)
+    depth_5: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    spread: Mapped[Decimal | None] = mapped_column(Numeric(10, 6), nullable=True)
+    src: Mapped[str] = mapped_column(Text, nullable=False)
+
+    collection: Mapped[Collection] = relationship(back_populates="prices")
+
+
+class Sale(Base):
+    __tablename__ = "sales"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    collection_id: Mapped[int] = mapped_column(ForeignKey("collections.id"), nullable=False)
+    ts: Mapped[datetime] = mapped_column(nullable=False)
+    price: Mapped[Decimal] = mapped_column(Numeric(24, 6), nullable=False)
+    tx_hash: Mapped[str | None] = mapped_column(Text, nullable=True)
+    src: Mapped[str] = mapped_column(Text, nullable=False)
+
+    collection: Mapped[Collection] = relationship(back_populates="sales")
+
+
+class Alert(Base):
+    __tablename__ = "alerts"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
+    collection_id: Mapped[int] = mapped_column(ForeignKey("collections.id"), nullable=False)
+    ts: Mapped[datetime] = mapped_column(nullable=False)
+    type: Mapped[str] = mapped_column(Text, nullable=False)
+    payload: Mapped[dict] = mapped_column(JSON, nullable=False)
+
+
+__all__ = [
+    "Alert",
+    "Collection",
+    "Market",
+    "Price",
+    "Sale",
+    "User",
+    "Watch",
+]

--- a/sticker_watcher/redis.py
+++ b/sticker_watcher/redis.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import asyncio
+
+import redis.asyncio as redis
+
+from .config import get_settings
+
+_settings = get_settings()
+
+redis_client = redis.from_url(_settings.redis_dsn, encoding="utf-8", decode_responses=True)
+lock = asyncio.Lock()
+
+__all__ = ["redis_client", "lock"]

--- a/sticker_watcher/services/__init__.py
+++ b/sticker_watcher/services/__init__.py
@@ -1,0 +1,3 @@
+from . import repository
+
+__all__ = ["repository"]

--- a/sticker_watcher/services/adapter_factory.py
+++ b/sticker_watcher/services/adapter_factory.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ..adapters import HarborAdapter, MarketAdapter, MrktAdapter, PalaceAdapter, PixelAdapter
+from ..config import get_settings
+
+
+class AdapterFactory:
+    def __init__(self) -> None:
+        self.settings = get_settings()
+
+    def create(self, market_code: str, meta: dict[str, Any]) -> MarketAdapter:
+        if market_code == "harbor":
+            base_url = meta.get("base_url") or self.settings.harbor_api_url
+            return HarborAdapter(base_url=base_url)
+        if market_code == "mrkt":
+            return MrktAdapter(
+                base_url=meta["base_url"],
+                init_data=meta["init_data"],
+                session_headers=meta.get("headers", {}),
+            )
+        if market_code == "palace":
+            return PalaceAdapter(
+                base_url=meta["base_url"],
+                init_data=meta["init_data"],
+                session_headers=meta.get("headers", {}),
+            )
+        if market_code == "pixel":
+            return PixelAdapter(
+                base_url=meta["base_url"],
+                init_data=meta["init_data"],
+                session_headers=meta.get("headers", {}),
+            )
+        raise ValueError(f"Unsupported market: {market_code}")
+
+
+__all__ = ["AdapterFactory"]

--- a/sticker_watcher/services/anti_spam.py
+++ b/sticker_watcher/services/anti_spam.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from redis.asyncio import Redis
+
+from ..config import Settings
+
+
+class AntiSpam:
+    def __init__(self, redis: Redis, settings: Settings) -> None:
+        self.redis = redis
+        self.settings = settings
+
+    async def allow_push(self, user_id: int, event_key: str, now: datetime) -> bool:
+        if await self._user_on_cooldown(user_id, now):
+            return False
+        if await self._event_on_cooldown(user_id, event_key, now):
+            return False
+        await self._mark_user(user_id, now)
+        await self._mark_event(user_id, event_key, now)
+        return True
+
+    async def _user_on_cooldown(self, user_id: int, now: datetime) -> bool:
+        key = f"user:cooldown:{user_id}"
+        ttl = await self.redis.ttl(key)
+        if ttl > 0:
+            return True
+        return False
+
+    async def _event_on_cooldown(self, user_id: int, event_key: str, now: datetime) -> bool:
+        key = f"event:cooldown:{user_id}:{event_key}"
+        ttl = await self.redis.ttl(key)
+        return ttl > 0
+
+    async def _mark_user(self, user_id: int, now: datetime) -> None:
+        key = f"user:cooldown:{user_id}"
+        await self.redis.set(
+            key,
+            int(now.timestamp()),
+            ex=self.settings.alerts.min_interval_sec,
+        )
+
+    async def _mark_event(self, user_id: int, event_key: str, now: datetime) -> None:
+        key = f"event:cooldown:{user_id}:{event_key}"
+        await self.redis.set(
+            key,
+            int(now.timestamp()),
+            ex=self.settings.alerts.same_event_cooldown_sec,
+        )
+
+
+__all__ = ["AntiSpam"]

--- a/sticker_watcher/services/digest.py
+++ b/sticker_watcher/services/digest.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+from collections import Counter
+from collections.abc import Iterable
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+from redis.asyncio import Redis
+from sqlalchemy import and_, select
+
+from ..config import Settings, get_settings
+from ..db import SessionLocal
+from ..models import tables as db_models
+from . import repository
+from .notifier import Notifier
+from .types import AlertEvent
+
+
+class DigestManager:
+    def __init__(self, notifier: Notifier, redis: Redis, settings: Settings | None = None) -> None:
+        self.notifier = notifier
+        self.redis = redis
+        self.settings = settings or get_settings()
+
+    async def handle_event(self, event: AlertEvent, deeplink: str | None) -> None:
+        if event.notify_instantly:
+            await self.notifier.handle_event(event, deeplink)
+            return
+        await self._queue_event(event)
+
+    async def _queue_event(self, event: AlertEvent) -> None:
+        record = {
+            "collection_id": event.collection_id,
+            "collection_code": event.collection_code,
+            "collection_name": event.collection_name,
+            "market_code": event.market_code,
+            "payload": dict(event.payload),
+            "event_type": event.type.value,
+            "ts": event.ts.isoformat(),
+        }
+        data = json.dumps(record)
+        for user_id in event.user_ids:
+            key = f"digest:15m:{user_id}"
+            await self.redis.rpush(key, data)
+
+    async def flush_quarter(self) -> None:
+        keys = await self.redis.keys("digest:15m:*")
+        for key in keys:
+            user_id = int(key.split(":")[-1])
+            items = await self.redis.lrange(key, 0, -1)
+            await self.redis.delete(key)
+            if not items:
+                continue
+            summary = self._aggregate_quarter_items(items)
+            text_lines = ["🧩 15-мин отчёт"]
+            for entry in summary:
+                events = ", ".join(f"{etype}:{count}" for etype, count in entry["events"].items())
+                text_lines.append(
+                    f"• {entry['market']} | {entry['collection']}: floor {entry['floor']} TON, depth5 {entry['depth']}; {events}"
+                )
+            await self.notifier.send_digest(user_id, "\n".join(text_lines), key="15m")
+
+    def _aggregate_quarter_items(self, items: Iterable[str]) -> Iterable[dict[str, str]]:
+        grouped: dict[tuple[str, str], dict[str, object]] = {}
+        for raw in items:
+            payload = json.loads(raw)
+            key = (payload["market_code"], payload["collection_name"])
+            entry = grouped.setdefault(
+                key,
+                {
+                    "market": payload["market_code"].upper(),
+                    "collection": payload["collection_name"],
+                    "floor": payload["payload"].get("floor"),
+                    "depth": payload["payload"].get("depth_5"),
+                    "events": Counter(),
+                },
+            )
+            entry["events"][payload["event_type"]] += 1
+            if payload["payload"].get("floor"):
+                entry["floor"] = payload["payload"].get("floor")
+            if payload["payload"].get("depth_5") is not None:
+                entry["depth"] = payload["payload"].get("depth_5")
+        return grouped.values()
+
+    async def send_daily_digest(self, label: str) -> None:
+        async with SessionLocal() as session:
+            users = await repository.get_enabled_digest_users(session)  # type: ignore[name-defined]
+        for user in users:
+            text = await self._build_daily_digest_text(user)
+            if text:
+                await self.notifier.send_digest(user.tg_id, text, key=f"daily:{label}")
+
+    async def _build_daily_digest_text(self, user: db_models.User) -> str | None:
+        async with SessionLocal() as session:
+            watches = await repository.list_watches(session, user)
+            if not watches:
+                return None
+            lines = ["📰 Дайджест"]
+            for collection, market, _ in watches:
+                latest_price = await self._fetch_latest_price(session, collection.id)
+                change = await self._compute_change(session, collection.id)
+                if latest_price is None:
+                    continue
+                change_str = f", Δ24ч {change:+.2f}%" if change is not None else ""
+                lines.append(
+                    f"• {market.code.upper()} | {collection.name}: floor {latest_price:.2f} TON{change_str}"
+                )
+            return "\n".join(lines)
+
+    async def _fetch_latest_price(self, session, collection_id: int) -> float | None:
+        stmt = (
+            select(db_models.Price.floor)
+            .where(db_models.Price.collection_id == collection_id)
+            .order_by(db_models.Price.ts.desc())
+            .limit(1)
+        )
+        value = (await session.execute(stmt)).scalar_one_or_none()
+        return float(value) if value is not None else None
+
+    async def _compute_change(self, session, collection_id: int) -> float | None:
+        cutoff = datetime.now(UTC) - timedelta(hours=24)
+        stmt = (
+            select(db_models.Price.ts, db_models.Price.floor)
+            .where(
+                and_(
+                    db_models.Price.collection_id == collection_id,
+                    db_models.Price.ts >= cutoff,
+                )
+            )
+            .order_by(db_models.Price.ts.asc())
+        )
+        rows = (await session.execute(stmt)).all()
+        if len(rows) < 2:
+            return None
+        start = Decimal(rows[0][1])
+        end = Decimal(rows[-1][1])
+        if start == 0:
+            return None
+        return float((end - start) / start * Decimal(100))
+
+
+__all__ = ["DigestManager"]

--- a/sticker_watcher/services/events.py
+++ b/sticker_watcher/services/events.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from enum import Enum
+
+
+class EventType(str, Enum):
+    FLOOR_BELOW = "FLOOR_BELOW"
+    UNDER_FLOOR_RARE = "UNDER_FLOOR_RARE"
+    THIN_FLOOR = "THIN_FLOOR"
+    DROP_SPIKE = "DROP_SPIKE"
+    VOLUME_SPIKE = "VOLUME_SPIKE"
+
+
+__all__ = ["EventType"]

--- a/sticker_watcher/services/formatter.py
+++ b/sticker_watcher/services/formatter.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from .events import EventType
+from .types import AlertEvent
+
+
+def format_event(event: AlertEvent) -> str:
+    market = event.market_code.upper()
+    collection = event.collection_name
+    floor = event.payload.get("floor")
+    depth = event.payload.get("depth_5")
+    if event.type == EventType.FLOOR_BELOW:
+        threshold = event.payload.get("threshold")
+        return (
+            f"⚡ {collection} — {market}: floor {floor} TON."
+            + (f" Порог: {threshold} TON." if threshold else "")
+        )
+    if event.type == EventType.UNDER_FLOOR_RARE:
+        listings = event.payload.get("listings", [])
+        if listings:
+            listing = listings[0]
+            price = listing.get("price")
+            return (
+                f"⚡ {collection} — {market}: редкий листинг {price} TON"
+                f" (floor {floor} TON)."
+            )
+    if event.type == EventType.THIN_FLOOR:
+        return f"🧩 {market} | {collection}: floor {floor} TON, depth5 {depth}."
+    if event.type == EventType.DROP_SPIKE:
+        drop = event.payload.get("drop_pct")
+        return (
+            f"⚡ {collection} — {market}: floor {floor} TON ({drop:.2f}% за 15м)."
+        )
+    if event.type == EventType.VOLUME_SPIKE:
+        volume = event.payload.get("volume")
+        return f"⚡ {collection} — {market}: рост объёма {volume}."
+    return f"ℹ️ {collection} — {market}: событие {event.type.value}."
+
+
+__all__ = ["format_event"]

--- a/sticker_watcher/services/metrics.py
+++ b/sticker_watcher/services/metrics.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal, InvalidOperation
+from statistics import median, pstdev
+
+from ..adapters import Listing
+
+
+@dataclass(slots=True)
+class MarketSnapshot:
+    ts: datetime
+    floor: Decimal
+    depth_5: int
+    listings: Sequence[Listing]
+
+
+def calculate_floor(listings: Sequence[Listing]) -> Decimal | None:
+    return listings[0].price if listings else None
+
+
+def calculate_depth(listings: Sequence[Listing], floor: Decimal, delta_pct: float) -> int:
+    upper = floor * (Decimal(1) + Decimal(delta_pct) / Decimal(100))
+    return sum(1 for item in listings if floor <= item.price <= upper)
+
+
+def calculate_volatility(history: Sequence[Decimal]) -> Decimal:
+    if len(history) < 2:
+        return Decimal(0)
+    floats = [float(value) for value in history]
+    return Decimal(str(pstdev(floats)))
+
+
+def calculate_median_floor(history: Sequence[Decimal]) -> Decimal | None:
+    if not history:
+        return None
+    try:
+        return Decimal(str(median(history)))
+    except InvalidOperation:
+        return None
+
+
+class RollingSeries:
+    def __init__(self, maxlen: int, ttl: timedelta | None = None) -> None:
+        self._values: deque[tuple[datetime, Decimal]] = deque(maxlen=maxlen)
+        self._ttl = ttl
+
+    def add(self, ts: datetime, value: Decimal) -> None:
+        self._values.append((ts, value))
+        self._trim()
+
+    def values(self) -> Sequence[Decimal]:
+        self._trim()
+        return [value for _, value in self._values]
+
+    def items(self) -> Sequence[tuple[datetime, Decimal]]:
+        self._trim()
+        return list(self._values)
+
+    def value_ago(self, delta: timedelta) -> Decimal | None:
+        if not self._values:
+            return None
+        cutoff = datetime.now(UTC) - delta
+        for ts, value in reversed(self._values):
+            if ts <= cutoff:
+                return value
+        return self._values[0][1]
+
+    def _trim(self) -> None:
+        if self._ttl is None:
+            return
+        cutoff = datetime.now(UTC) - self._ttl
+        while self._values and self._values[0][0] < cutoff:
+            self._values.popleft()
+
+
+__all__ = [
+    "MarketSnapshot",
+    "RollingSeries",
+    "calculate_depth",
+    "calculate_floor",
+    "calculate_median_floor",
+    "calculate_volatility",
+]

--- a/sticker_watcher/services/notifier.py
+++ b/sticker_watcher/services/notifier.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+from aiogram import Bot
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+from sqlalchemy.dialects.postgresql import insert
+
+from ..config import Settings, get_settings
+from ..db import SessionLocal
+from ..models import tables as db_models
+from .anti_spam import AntiSpam
+from .formatter import format_event
+from .types import AlertEvent
+
+logger = logging.getLogger(__name__)
+
+
+class Notifier:
+    def __init__(self, bot: Bot, anti_spam: AntiSpam, settings: Settings | None = None) -> None:
+        self.bot = bot
+        self.anti_spam = anti_spam
+        self.settings = settings or get_settings()
+
+    async def handle_event(self, event: AlertEvent, deeplink: str | None = None) -> None:
+        text = format_event(event)
+        for user_id in event.user_ids:
+            await self._store_alert(user_id, event)
+            event_key = f"{event.collection_id}:{event.type.value}"
+            if not await self.anti_spam.allow_push(user_id, event_key, event.ts):
+                continue
+            if event.notify_instantly:
+                await self._send_message(user_id, text, deeplink)
+
+    async def _send_message(self, user_id: int, text: str, deeplink: str | None) -> None:
+        markup = None
+        if deeplink:
+            markup = InlineKeyboardMarkup(
+                inline_keyboard=[[InlineKeyboardButton(text="Открыть", url=deeplink)]]
+            )
+        try:
+            await self.bot.send_message(user_id, text, reply_markup=markup, disable_notification=False)
+        except Exception as exc:  # pragma: no cover - network errors
+            logger.warning("Failed to send message to %s: %s", user_id, exc)
+
+    async def send_digest(self, user_id: int, text: str, key: str) -> None:
+        event_key = f"digest:{key}"
+        if not await self.anti_spam.allow_push(user_id, event_key, datetime.utcnow()):
+            return
+        await self._send_message(user_id, text, None)
+
+    async def _store_alert(self, user_id: int, event: AlertEvent) -> None:
+        async with SessionLocal() as session:
+            stmt = insert(db_models.Alert).values(
+                user_id=user_id,
+                collection_id=event.collection_id,
+                ts=event.ts,
+                type=event.type.value,
+                payload=dict(event.payload),
+            )
+            await session.execute(stmt)
+            await session.commit()
+
+
+__all__ = ["Notifier"]

--- a/sticker_watcher/services/repository.py
+++ b/sticker_watcher/services/repository.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime
+from decimal import Decimal
+
+from sqlalchemy import and_, select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..models import tables as db_models
+
+
+async def ensure_user(session: AsyncSession, tg_id: int, tz: str) -> db_models.User:
+    stmt = select(db_models.User).where(db_models.User.tg_id == tg_id)
+    result = await session.execute(stmt)
+    user = result.scalar_one_or_none()
+    if user:
+        if user.tz != tz:
+            user.tz = tz
+        return user
+    user = db_models.User(tg_id=tg_id, tz=tz)
+    session.add(user)
+    await session.flush()
+    return user
+
+
+async def get_market(session: AsyncSession, code: str) -> db_models.Market | None:
+    stmt = select(db_models.Market).where(db_models.Market.code == code)
+    return (await session.execute(stmt)).scalar_one_or_none()
+
+
+async def get_collection(
+    session: AsyncSession,
+    market_code: str,
+    collection_code: str,
+) -> db_models.Collection | None:
+    stmt = (
+        select(db_models.Collection)
+        .join(db_models.Market)
+        .where(
+            and_(
+                db_models.Market.code == market_code,
+                db_models.Collection.code == collection_code,
+            )
+        )
+    )
+    return (await session.execute(stmt)).scalar_one_or_none()
+
+
+async def add_watch(
+    session: AsyncSession,
+    user: db_models.User,
+    collection: db_models.Collection,
+    threshold: Decimal | None,
+) -> db_models.Watch:
+    stmt = (
+        insert(db_models.Watch)
+        .values(
+            user_id=user.id,
+            collection_id=collection.id,
+            threshold_ton=threshold,
+            enabled=True,
+        )
+        .on_conflict_do_update(
+            index_elements=[db_models.Watch.user_id, db_models.Watch.collection_id],
+            set_={"threshold_ton": threshold, "enabled": True},
+        )
+        .returning(db_models.Watch)
+    )
+    result = await session.execute(stmt)
+    return result.scalar_one()
+
+
+async def remove_watch(
+    session: AsyncSession,
+    user: db_models.User,
+    collection: db_models.Collection,
+) -> None:
+    stmt = (
+        select(db_models.Watch)
+        .where(
+            and_(
+                db_models.Watch.user_id == user.id,
+                db_models.Watch.collection_id == collection.id,
+            )
+        )
+    )
+    watch = (await session.execute(stmt)).scalar_one_or_none()
+    if watch:
+        watch.enabled = False
+
+
+async def list_watches(session: AsyncSession, user: db_models.User) -> Sequence[tuple[db_models.Collection, db_models.Market, db_models.Watch]]:
+    stmt = (
+        select(db_models.Collection, db_models.Market, db_models.Watch)
+        .join(db_models.Watch, db_models.Watch.collection_id == db_models.Collection.id)
+        .join(db_models.Market, db_models.Market.id == db_models.Collection.market_id)
+        .where(
+            and_(
+                db_models.Watch.user_id == user.id,
+                db_models.Watch.enabled.is_(True),
+            )
+        )
+        .order_by(db_models.Market.code, db_models.Collection.code)
+    )
+    return (await session.execute(stmt)).all()
+
+
+async def set_mute(session: AsyncSession, user: db_models.User, until: datetime | None) -> None:
+    user.mute_until = until
+
+
+async def get_enabled_digest_users(session: AsyncSession) -> Sequence[db_models.User]:
+    stmt = select(db_models.User).where(db_models.User.mute_until.is_(None))
+    return (await session.execute(stmt)).scalars().all()
+
+
+__all__ = [
+    "add_watch",
+    "ensure_user",
+    "get_collection",
+    "get_enabled_digest_users",
+    "get_market",
+    "list_watches",
+    "remove_watch",
+    "set_mute",
+]

--- a/sticker_watcher/services/scheduler.py
+++ b/sticker_watcher/services/scheduler.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import timedelta
+from zoneinfo import ZoneInfo
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.interval import IntervalTrigger
+from sqlalchemy import select
+
+from ..bot import bot
+from ..config import Settings, get_settings
+from ..db import SessionLocal
+from ..models import tables as db_models
+from ..redis import redis_client
+from .adapter_factory import AdapterFactory
+from .anti_spam import AntiSpam
+from .digest import DigestManager
+from .metrics import RollingSeries
+from .notifier import Notifier
+from .watchers import CollectionWatcher, WatcherContext
+
+logger = logging.getLogger(__name__)
+
+POLL_INTERVALS = {
+    "harbor": 15,
+    "mrkt": 25,
+    "palace": 25,
+    "pixel": 25,
+}
+
+
+class WatchScheduler:
+    def __init__(self, settings: Settings | None = None) -> None:
+        self.settings = settings or get_settings()
+        self.scheduler = AsyncIOScheduler(timezone=ZoneInfo(self.settings.timezone))
+        self.adapter_factory = AdapterFactory()
+        self.watchers: dict[int, CollectionWatcher] = {}
+        anti_spam = AntiSpam(redis_client, self.settings)
+        self.notifier = Notifier(bot, anti_spam, self.settings)
+        self.digest_manager = DigestManager(self.notifier, redis_client, self.settings)
+
+    async def start(self) -> None:
+        await self._load_watchers()
+        self.scheduler.add_job(self.digest_manager.flush_quarter, CronTrigger(minute="*/15", second=5))
+        for time_str in self.settings.digest.times:
+            hour, minute = map(int, time_str.split(":"))
+            self.scheduler.add_job(
+                self.digest_manager.send_daily_digest,
+                CronTrigger(hour=hour, minute=minute, second=0),
+                args=(time_str,),
+            )
+        self.scheduler.start()
+
+    async def shutdown(self) -> None:
+        await self.scheduler.shutdown(wait=False)
+        await asyncio.gather(*(watcher.context.adapter.close() for watcher in self.watchers.values()))
+
+    async def _load_watchers(self) -> None:
+        async with SessionLocal() as session:
+            stmt = (
+                select(db_models.Collection, db_models.Market)
+                .join(db_models.Market, db_models.Market.id == db_models.Collection.market_id)
+                .join(db_models.Watch, db_models.Watch.collection_id == db_models.Collection.id)
+                .where(db_models.Watch.enabled.is_(True))
+                .group_by(db_models.Collection.id, db_models.Market.id)
+            )
+            result = await session.execute(stmt)
+            rows = result.all()
+
+        for collection, market in rows:
+            if collection.id in self.watchers:
+                continue
+            adapter = self.adapter_factory.create(market.code, collection.meta)
+            context = WatcherContext(
+                collection=collection,
+                market=market,
+                adapter=adapter,
+                floor_history=RollingSeries(maxlen=500, ttl=timedelta(hours=24)),
+                volatility_history=RollingSeries(maxlen=500, ttl=timedelta(hours=2)),
+            )
+            watcher = CollectionWatcher(context, self.settings)
+            await watcher.initialize()
+            self.watchers[collection.id] = watcher
+            interval = POLL_INTERVALS.get(market.code, 30)
+            self.scheduler.add_job(
+                self._poll_collection,
+                IntervalTrigger(seconds=interval, jitter=5),
+                args=(collection.id,),
+                id=f"collection-{collection.id}",
+                replace_existing=True,
+            )
+
+    async def _poll_collection(self, collection_id: int) -> None:
+        watcher = self.watchers.get(collection_id)
+        if not watcher:
+            return
+        events = await watcher.poll()
+        if not events:
+            return
+        for event in events:
+            meta = watcher.context.collection.meta or {}
+            deeplink = meta.get("deeplink")
+            await self.digest_manager.handle_event(event, deeplink)
+
+
+__all__ = ["WatchScheduler"]

--- a/sticker_watcher/services/types.py
+++ b/sticker_watcher/services/types.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+from .events import EventType
+
+
+@dataclass(slots=True)
+class AlertEvent:
+    type: EventType
+    collection_id: int
+    market_code: str
+    collection_code: str
+    collection_name: str
+    payload: Mapping[str, Any]
+    ts: datetime
+    user_ids: tuple[int, ...]
+    notify_instantly: bool = True
+
+
+@dataclass(slots=True)
+class WatchConfig:
+    threshold_ton: Decimal | None
+    user_id: int
+
+
+__all__ = ["AlertEvent", "WatchConfig"]

--- a/sticker_watcher/services/watchers.py
+++ b/sticker_watcher/services/watchers.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+from sqlalchemy import and_, or_, select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..adapters import Listing, MarketAdapter
+from ..config import Settings, get_settings
+from ..db import SessionLocal
+from ..models import tables as db_models
+from .events import EventType
+from .metrics import (
+    RollingSeries,
+    calculate_depth,
+    calculate_floor,
+    calculate_median_floor,
+    calculate_volatility,
+)
+from .types import AlertEvent
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class WatcherContext:
+    collection: db_models.Collection
+    market: db_models.Market
+    adapter: MarketAdapter
+    floor_history: RollingSeries
+    volatility_history: RollingSeries
+
+
+class CollectionWatcher:
+    def __init__(self, context: WatcherContext, settings: Settings | None = None) -> None:
+        self.context = context
+        self.settings = settings or get_settings()
+        self._lock = asyncio.Lock()
+
+    async def initialize(self) -> None:
+        async with SessionLocal() as session:
+            await self._load_history(session)
+
+    async def poll(self) -> Sequence[AlertEvent]:
+        async with self._lock:
+            now = datetime.now(UTC)
+            listings = await self.context.adapter.fetch_active_listings(self.context.collection.code)
+            if not listings:
+                return []
+            floor = calculate_floor(listings)
+            if floor is None:
+                return []
+            depth_5 = calculate_depth(listings, floor, self.settings.alerts.depth_delta_pct)
+            self.context.floor_history.add(now, floor)
+            self.context.volatility_history.add(now, floor)
+            volatility = calculate_volatility(self.context.volatility_history.values())
+            median_floor_24h = calculate_median_floor(self.context.floor_history.values())
+            events = await self._detect_events(
+                listings=listings,
+                now=now,
+                floor=floor,
+                depth_5=depth_5,
+                median_floor=median_floor_24h,
+                volatility=volatility,
+            )
+            await self._persist_price(now, floor, depth_5, volatility)
+            return events
+
+    async def _load_history(self, session: AsyncSession) -> None:
+        stmt = (
+            select(db_models.Price.ts, db_models.Price.floor)
+            .where(db_models.Price.collection_id == self.context.collection.id)
+            .order_by(db_models.Price.ts.desc())
+            .limit(500)
+        )
+        rows = (await session.execute(stmt)).all()
+        for ts, floor in reversed(rows):
+            if floor is None:
+                continue
+            self.context.floor_history.add(ts, Decimal(floor))
+            self.context.volatility_history.add(ts, Decimal(floor))
+
+    async def _persist_price(self, ts: datetime, floor: Decimal, depth_5: int, volatility: Decimal) -> None:
+        async with SessionLocal() as session:
+            stmt = insert(db_models.Price).values(
+                collection_id=self.context.collection.id,
+                ts=ts,
+                floor=floor,
+                depth_5=depth_5,
+                spread=None,
+                src=self.context.market.code,
+            )
+            await session.execute(stmt)
+            await session.commit()
+
+    async def _detect_events(
+        self,
+        listings: Sequence[Listing],
+        now: datetime,
+        floor: Decimal,
+        depth_5: int,
+        median_floor: Decimal | None,
+        volatility: Decimal,
+    ) -> Sequence[AlertEvent]:
+        watchers = await self._load_watchers(now)
+        if not watchers:
+            return []
+        events: list[AlertEvent] = []
+        triggered_watches = [
+            watch
+            for watch in watchers
+            if watch.threshold_ton is not None and floor <= watch.threshold_ton
+        ]
+        if triggered_watches:
+            floor_below_users = [watch.user_id for watch in triggered_watches]
+            min_threshold = min(Decimal(watch.threshold_ton) for watch in triggered_watches if watch.threshold_ton is not None)
+            events.append(
+                AlertEvent(
+                    type=EventType.FLOOR_BELOW,
+                    collection_id=self.context.collection.id,
+                    market_code=self.context.market.code,
+                    collection_code=self.context.collection.code,
+                    collection_name=self.context.collection.name,
+                    payload={
+                        "floor": str(floor),
+                        "depth_5": depth_5,
+                        "median_floor_24h": str(median_floor) if median_floor else None,
+                        "threshold": str(min_threshold),
+                    },
+                    ts=now,
+                    user_ids=tuple(floor_below_users),
+                    notify_instantly=True,
+                )
+            )
+        if median_floor is not None:
+            under_floor_listings = [
+                listing
+                for listing in listings
+                if listing.price <= median_floor * (Decimal(1) - Decimal(self.settings.alerts.under_floor_pct) / Decimal(100))
+            ]
+            if under_floor_listings:
+                events.append(
+                    AlertEvent(
+                        type=EventType.UNDER_FLOOR_RARE,
+                        collection_id=self.context.collection.id,
+                        market_code=self.context.market.code,
+                        collection_code=self.context.collection.code,
+                        collection_name=self.context.collection.name,
+                        payload={
+                            "floor": str(floor),
+                            "median_floor_24h": str(median_floor),
+                            "listings": [
+                                {"asset_id": listing.asset_id, "price": str(listing.price)}
+                                for listing in under_floor_listings
+                            ],
+                        },
+                        ts=now,
+                        user_ids=tuple(watch.user_id for watch in watchers),
+                        notify_instantly=True,
+                    )
+                )
+        if depth_5 <= self.settings.alerts.thin_floor_min_lots:
+            events.append(
+                AlertEvent(
+                    type=EventType.THIN_FLOOR,
+                    collection_id=self.context.collection.id,
+                    market_code=self.context.market.code,
+                    collection_code=self.context.collection.code,
+                    collection_name=self.context.collection.name,
+                    payload={
+                        "floor": str(floor),
+                        "depth_5": depth_5,
+                    },
+                    ts=now,
+                    user_ids=tuple(watch.user_id for watch in watchers),
+                    notify_instantly=False,
+                )
+            )
+        drop_reference = self.context.floor_history.value_ago(timedelta(minutes=15))
+        if drop_reference and drop_reference > 0:
+            drop_pct = (floor - drop_reference) / drop_reference * Decimal(100)
+            if drop_pct <= Decimal(-3):
+                events.append(
+                    AlertEvent(
+                        type=EventType.DROP_SPIKE,
+                        collection_id=self.context.collection.id,
+                        market_code=self.context.market.code,
+                        collection_code=self.context.collection.code,
+                        collection_name=self.context.collection.name,
+                        payload={
+                            "floor": str(floor),
+                            "drop_pct": float(drop_pct),
+                            "reference_floor": str(drop_reference),
+                        },
+                        ts=now,
+                        user_ids=tuple(watch.user_id for watch in watchers),
+                        notify_instantly=True,
+                    )
+                )
+        return events
+
+    async def _load_watchers(self, now: datetime) -> Sequence[db_models.Watch]:
+        async with SessionLocal() as session:
+            stmt = (
+                select(db_models.Watch)
+                .where(
+                    and_(
+                        db_models.Watch.collection_id == self.context.collection.id,
+                        db_models.Watch.enabled.is_(True),
+                        or_(
+                            db_models.User.mute_until.is_(None),
+                            db_models.User.mute_until < now,
+                        ),
+                    )
+                )
+                .join(db_models.User, db_models.User.id == db_models.Watch.user_id)
+            )
+            result = await session.execute(stmt)
+            return [row[0] for row in result.all()]
+
+
+__all__ = ["CollectionWatcher", "WatcherContext"]

--- a/sticker_watcher/utils/time.py
+++ b/sticker_watcher/utils/time.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from datetime import datetime, time, timedelta
+
+import pytz
+
+
+def next_occurrence(now: datetime, target: time, tz: str) -> datetime:
+    zone = pytz.timezone(tz)
+    localized_now = now.astimezone(zone)
+    candidate = zone.localize(datetime.combine(localized_now.date(), target))
+    if candidate <= localized_now:
+        candidate += timedelta(days=1)
+    return candidate.astimezone(pytz.UTC)
+
+
+__all__ = ["next_occurrence"]

--- a/sticker_watcher/worker.py
+++ b/sticker_watcher/worker.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import asyncio
+import signal
+
+from .bot import bot
+from .config import get_settings
+from .logging import setup_logging
+from .services.scheduler import WatchScheduler
+
+
+async def main() -> None:
+    settings = get_settings()
+    setup_logging()
+    scheduler = WatchScheduler(settings)
+    await scheduler.start()
+
+    stop_event = asyncio.Event()
+
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        asyncio.get_running_loop().add_signal_handler(sig, stop_event.set)
+
+    await stop_event.wait()
+    await scheduler.shutdown()
+    await bot.session.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- scaffold sticker_watcher package with adapters, services, bot commands, and scheduler for Harbor, MRKT, Palace and Pixel monitoring
- wire FastAPI webhook, aiogram bot, APScheduler worker, and Redis/Postgres integration with Docker deployment assets
- add metrics, alerting, digest aggregation, and supporting utilities for anti-spam, formatting, and database schema creation

## Testing
- ruff check sticker_watcher scripts
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ceb9e268c88325830697575ab4c297